### PR TITLE
Stop using the url method from Sinatra

### DIFF
--- a/web/views/status.erb
+++ b/web/views/status.erb
@@ -68,7 +68,7 @@
   </div>
 </div>
 
-<a href="<%= url(:statuses) %>">
+<a href="<%= root_path %>statuses">
   <small>&larr; back to all statuses</small>
 </a>
 


### PR DESCRIPTION
Sidekiq 4.2 removes its dependency with Sinatra so some methods like
that one don't work anymore. This should make it more standard.